### PR TITLE
add -z option to uliweb load and loadtable command

### DIFF
--- a/uliweb/contrib/orm/commands.py
+++ b/uliweb/contrib/orm/commands.py
@@ -598,11 +598,14 @@ class LoadCommand(SQLCommandMixin, Command):
             help='Character encoding used in text file. Default is "utf-8".'),
         make_option('-p', '--project', dest='all', default=True, action='store_false',
             help='Process all tables defined in engine include tables which are not defined in current application.'),
+        make_option('-z', dest='zipfile', 
+            help='Extract zip file into directory which is specified by -d option.'),
     )
     check_apps = True
     
     def handle(self, options, global_options, *args):
         from uliweb import orm
+        from zipfile import ZipFile
         
         if args:
             message = """This command will delete all data of [%s]-[%s] before loading, 
@@ -619,6 +622,19 @@ are you sure to load data""" % options.engine
         path = os.path.join(options.dir, options.engine)
         if not os.path.exists(path):
             os.makedirs(path)
+
+        # extract zip file to path
+        if options.zipfile:
+            zipfile = None
+            try:
+                zipfile = ZipFile(options.zipfile, 'r')
+                zipfile.extractall(path)
+            except:
+                log.exception("There are something wrong when extract zip file [%s]" % options.zipfile)
+                sys.exit(1)
+            finally:
+                if zipfile:
+                    zipfile.close()
         
         engine = get_engine(options, global_options)
 
@@ -668,10 +684,13 @@ class LoadTableCommand(SQLCommandMixin, Command):
             help='delimiter character used in text file. Default is ",".'),
         make_option('--encoding', dest='encoding', default='utf-8',
             help='Character encoding used in text file. Default is "utf-8".'),
+        make_option('-z', dest='zipfile', 
+            help='Extract zip file into directory which is specified by -d option.'),
     )
 
     def handle(self, options, global_options, *args):
         from uliweb import orm
+        from zipfile import ZipFile
         
         if args:
             message = """This command will delete all data of [%s]-[%s] before loading, 
@@ -685,6 +704,19 @@ are you sure to load data""" % (options.engine, ','.join(args))
         path = os.path.join(options.dir, options.engine)
         if not os.path.exists(path):
             os.makedirs(path)
+
+        # extract zip file to path
+        if options.zipfile:
+            zipfile = None
+            try:
+                zipfile = ZipFile(options.zipfile, 'r')
+                zipfile.extractall(path)
+            except:
+                log.exception("There are something wrong when extract zip file [%s]" % options.zipfile)
+                sys.exit(1)
+            finally:
+                if zipfile:
+                    zipfile.close()
         
         engine = get_engine(options, global_options)
 


### PR DESCRIPTION
关于 uliweb dump 和 uliweb load, 有些改进意见, 请参考!

应用场景:
我是将uliweb部署在嵌入式设备上使用的, 将设备上的数据库导入导出操作比较频繁.
为了能让导入导出自动化, 前端时间提出给 uliweb 加了个 -y 的option.(感谢你 的帮助和Chunlin兄的建议, 这个option很快就加上了)

通过这段时间的使用, 我发现 uliweb dump 和 uliweb dumptable 有个 -z option, 可以将数据库的数据导出成一个zip文件, 非常方便.
但是, 这个zip文件是没法通过 uliweb load 和 uliweb loadtable 导入的, 因为 load 和 loadtable 没有对应的 -z option.
只有将zip文件先解压, 然后通过load 和 loadtable 的 -d option 来指定解压的 文件夹来完成导入.

这里还有个问题, zip文件直接解压后的文件夹中缺少 engine name 的子文件夹, 也不能直接通过 -d 来导入.
ex.
# 导出比较简单

uliweb dump -z test.zip
# 导入则有点复杂

unzip test.zip -d test/default   # 这个的 default 是默认的 engine name
uliweb load -d test   # 上一步直接解压不会产生 default 子目录, 这一步就 导入不成功

改善方法:
给 load 和 loadtable 增加 -z option.
导入时, -z 可以将 dump 出来的 zip 文件直接导入到数据库.
导入时, -z 的解压路径就是 -d 指向的位置, 不指定 -d, 就用 -d的默认值 ./data

修改的代码参见附件, 已测试过. 仅供参考.

希望导入时能追加 -z 参数. ^_^
