### PR TITLE
ORM导出导入CSV文件列值为空

### DIFF
--- a/uliweb/contrib/orm/commands.py
+++ b/uliweb/contrib/orm/commands.py
@@ -169,12 +169,14 @@ def load_table(table, filename, con, delimiter=',', format=None,
         first_line = f.readline()
         if first_line.startswith('#'):
             first_line = first_line[1:]
-        fields = first_line.strip().split()
         n = 0
         count = 0
         if format:
+            fields = first_line.strip().split(delimiter)
             fin = csv.reader(f, delimiter=delimiter)
-            
+        else:
+            fields = first_line.strip().split()
+
         buf = []
         for line in fin:
             try:


### PR DESCRIPTION
修正用uliweb dump/dumptable -t导出得到csv文件，通过uliweb load/loadtable -t导入表除ID列外、其他列值为空的情况。导入csv文件中列名(第一行)解析不正确，没有按照delimiter符号进行split。
