### PR TITLE
解决 uliweb syncdb 时提示 找不到sequence.models 的问题

### DIFF
--- a/uliweb/contrib/sequence/settings.ini
+++ b/uliweb/contrib/sequence/settings.ini
@@ -1,5 +1,5 @@
 [MODELS]
-sequence = 'sequence.models.Sequence'
+sequence = 'uliweb.contrib.sequence.models.Sequence'
 
 [FUNCTIONS]
 get_sequence = 'sequence.get_sequence'


### PR DESCRIPTION
修正前使用 uliweb syncdb 创建 seqence表时有如下错误:
ImportError: No module named sequence.models
