### PR TITLE
fix bug: double quote string

### DIFF
--- a/uliweb/template_files/project/setup.py
+++ b/uliweb/template_files/project/setup.py
@@ -85,7 +85,7 @@ setup(
     description='{{=project_name}}',
     long_description=desc(),
     package_dir = {'{{=project_name}}':'apps'},
-    packages = ['{{=project_name.replace('-', '_')}}'],
+    packages = ["{{=project_name.replace('-', '_')}}"],
     include_package_data=True,
     zip_safe=False,
     platforms='any',


### PR DESCRIPTION
When I try to install uliweb in my PC, a syntax error happened which was caused by a string without double quotation.