### PR TITLE
fix error of inspect.getargspec when ok_url is partial

### DIFF
--- a/uliweb/utils/generic.py
+++ b/uliweb/utils/generic.py
@@ -913,8 +913,9 @@ class AddView(object):
             return errors
 
     def get_url(self, obj):
+        from functools import partial
         #guess ok_url kwargs, it could be (id) or (obj)
-        if callable(self.ok_url):
+        if callable(self.ok_url) and type(self.ok_url)!=partial:
             args = inspect.getargspec(self.ok_url).args
             kwargs = {}
             _dict = obj.to_dict()


### PR DESCRIPTION
现在的代码在rbac_man里会出问题,貌似你原来的代码能工作,但是后来改坏了
目前的代码在 args = inspect.getargspec(self.ok_url).args 这里, 如果 self.ok_url 是 particial的时候会出错
我恢复你原来的代码写法是可以正常工作的,但是因为我看不懂逻辑,所以还是提给你看看,你来修改吧